### PR TITLE
Add new select syntax

### DIFF
--- a/goless/selecting.py
+++ b/goless/selecting.py
@@ -60,6 +60,10 @@ def select(*cases):
     if isinstance(cases[0], list):
         if len(cases) != 1:
             raise TypeError("Select can be called either with a list of cases or multiple case arguments, but not both")
+        if len(cases[0]) == 0:
+            # Handle the case of an empty list as an argument, and prevent the raising of a SystemError by libev.
+            return
+        
         cases = cases[0]
     
     default = None

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -121,8 +121,9 @@ class SelectTests(BaseTests):
             
     def test_select_accepts_args(self):
         chan1 = goless.chan(1)
-        chosen, val = goless.select(goless.scase(chan1, 1))
-        self.assertIs(chosen, chan1)
+        scase = goless.scase(chan1, 1)
+        chosen, val = goless.select(scase)
+        self.assertIs(chosen, scase)
         self.assertIsNone(val)
         
     def test_select_raises_for_list_and_args(self):
@@ -136,3 +137,4 @@ class SelectTests(BaseTests):
             
     def test_select_with_no_args_should_do_nothing(self):
         goless.select()
+        goless.select([])


### PR DESCRIPTION
Select can now accept `*args` and will throw for a combination of a list and `*args` as discussed in #22
