### PR TITLE
Close channels in producer_consumer example

### DIFF
--- a/examples/producer_consumer.py
+++ b/examples/producer_consumer.py
@@ -22,16 +22,18 @@ def main():
     def produce():
         for i in range(10):
             msgs.send(i)
-        done.send()
+        msgs.close()
 
     def consume(name):
         for msg in msgs:
             out.send('%s:%s ' % (name, msg))
+        out.close()
 
     def logger():
         for msg in out:
             sys.stdout.write(msg)
         sys.stdout.write('\n')
+        done.send()
 
     goless.go(produce)
     goless.go(consume, "one")


### PR DESCRIPTION
The `examples/producer_consumer.py` script terminates before the `\n` line can be printed, at least when run with gevent on Python 2.7.13.

This changes each of the goroutines to close their channels when they're done sending data, and then only closing the `done` channel once all processing is actually done.