### PR TITLE
Fix #45 (test_raises_deadlock_if_no_goroutines hang)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,6 +20,6 @@ class BaseTests(unittest.TestCase):
     def setUp(self):
         be.yield_()
 
-        def doyield():
-            be.yield_()
-        self.addCleanup(doyield)
+    def tearDown(self):
+        be.yield_()
+        self.assertTrue(be.would_deadlock())

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -53,6 +53,8 @@ class SendCaseTests(BaseTests):
         assert_default_readiness()
         be.run(self.ch.send)
         self.assertFalse(self.ca.ready())
+        be.run(self.ch.recv)
+        assert_default_readiness()
 
     def test_executes(self):
         def recv():


### PR DESCRIPTION
Ensure tests clean up all tasklets/greenlets on completion; fix `select` test hang; fixes #45

`SendCaseTests.test_ready` was leaving a running tasklet/greenlet after completion, which caused `SelectTests.test_raises_deadlock_if_no_goroutines` to subsequently hang (since there's an extra task running unexpectedly).

In order to track this down and to prevent it from happening in the future, I added a `tearDown` method in `BaseTests` to assert that all tasks are cleaned up after tests run.