### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - python: pypy
       env:
       - TOX_ENV=pypy2gevent
-    - python: pypy3
+    - python: pypy
       env:
       - TOX_ENV=pypy3gevent
     - python: 2.7
@@ -41,16 +41,16 @@ before_install:
             DOWNLOAD_URL="https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.8.0-linux64.tar.bz2"
         fi
 
-        PYTHON_DIR="~/cache/${PYTHON_NAME}"
+        PYTHON_DIR="~/.cache/${PYTHON_NAME}"
         if [ ! -d ${PYTHON_DIR} ] ; then
             mkdir -p ${PYTHON_DIR}
             wget -qO- ${DOWNLOAD_URL} | tar jxf - --strip-components=1 -C ${PYTHON_DIR}
         fi
         export PATH=${PYTHON_DIR}/bin:${PATH}
     fi
-    if [[ $TOX_ENV = 27slptravis ]] && [ ! -d ~/cache/stackless-2.7.6 ]; then
+    if [[ $TOX_ENV = 27slptravis ]] && [ ! -d ~/.cache/stackless-2.7.6 ]; then
         wget http://www.robg3d.com/downloads/stackless-2.7.6_amd64.zip
-        unzip stackless-2.7.6_amd64.zip -d ~/cache/
+        unzip stackless-2.7.6_amd64.zip -d ~/.cache/
     fi
     set +e
 install:
@@ -65,8 +65,7 @@ after_success:
 cache:
   directories:
     - .tox
-    - $HOME/.cache/pip
-    - $HOME/cache
+    - $HOME/.cache
 # blacklist
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,60 @@
 language: python
-python:
-  - "2.7"
-env:
-  - TOX_ENV=26gevent
-  - TOX_ENV=27gevent
-  - TOX_ENV=pypygevent
-  - TOX_ENV=33gevent
-  - TOX_ENV=34gevent
-  - TOX_ENV=27slptravis
+matrix:
+  include:
+    - python: 2.6
+      env:
+      - TOX_ENV=26gevent
+    - python: 2.7
+      env:
+      - TOX_ENV=27gevent
+    - python: 3.3
+      env:
+      - TOX_ENV=33gevent
+    - python: 3.4
+      env:
+      - TOX_ENV=34gevent
+    - python: 3.5
+      env:
+      - TOX_ENV=35gevent
+    - python: 3.6
+      env:
+      - TOX_ENV=36gevent
+    - python: pypy
+      env:
+      - TOX_ENV=pypy2gevent
+    - python: pypy3
+      env:
+      - TOX_ENV=pypy3gevent
+    - python: 2.7
+      env:
+      - TOX_ENV=27slptravis
 before_install:
-  - if [ \"$TOX_ENV\" == \"27slptravis\" ]; then wget http://www.robg3d.com/downloads/stackless-2.7.6_amd64.zip; fi
-  - if [ \"$TOX_ENV\" == \"27slptravis\" ]; then unzip -q stackless-2.7.6_amd64.zip -d $HOME; fi
+  - |
+    set -e
+    if [[ $TOX_ENV == pypy* ]]; then
+        # Travis pypy versions are super old, so download manually.
+        if [[ $TOX_ENV == pypy2* ]]; then
+            PYTHON_NAME="pypy"
+            DOWNLOAD_URL="https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux64.tar.bz2"
+        elif [[ $TOX_ENV == pypy3* ]]; then
+            PYTHON_NAME="pypy3"
+            DOWNLOAD_URL="https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.8.0-linux64.tar.bz2"
+        fi
+
+        PYTHON_DIR="~/cache/${PYTHON_NAME}"
+        if [ ! -d ${PYTHON_DIR} ] ; then
+            mkdir -p ${PYTHON_DIR}
+            wget -qO- ${DOWNLOAD_URL} | tar jxf - --strip-components=1 -C ${PYTHON_DIR}
+        fi
+        export PATH=${PYTHON_DIR}/bin:${PATH}
+    fi
+    if [[ $TOX_ENV = 27slptravis ]] && [ ! -d ~/cache/stackless-2.7.6 ]; then
+        wget http://www.robg3d.com/downloads/stackless-2.7.6_amd64.zip
+        unzip stackless-2.7.6_amd64.zip -d ~/cache/
+    fi
+    set +e
 install:
-  - "pip install tox --download-cache $HOME/.pip-cache"
-  - "pip install coveralls --download-cache $HOME/.pip-cache"
+  - "pip install tox coveralls"
 script:
   - tox -e $TOX_ENV
 #after_failure:
@@ -24,7 +65,8 @@ after_success:
 cache:
   directories:
     - .tox
-    - $HOME/.pip-cache/
+    - $HOME/.cache/pip
+    - $HOME/cache
 # blacklist
 branches:
   except:

--- a/setup.py
+++ b/setup.py
@@ -10,16 +10,10 @@ try:
     # noinspection PyUnresolvedReferences
     import stackless
 except ImportError:
-    # See https://github.com/rgalanakis/goless/issues/21
-    # for why we need this (waiting for new gevent version).
-    if sys.version_info[0] == 3:
-        warnings.warn(
-            'You will need to install gevent from GitHub to use goless with '
-            'gevent under Python3. Run something like '
-            '"pip install git+https://github.com/surfly/gevent.git#gevent-egg"'
-        )
+    if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
+        requires.append('gevent==1.1')
     else:
-        requires.append('gevent>=1.0')
+        requires.append('gevent')
 
 setup(
     name='goless',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = 26gevent, 27gevent, pypygevent, 33gevent, 34gevent
+envlist = 26gevent, 27gevent, pypy2gevent, pypy2stackless, pypy3gevent, pypy3stackless, 33gevent, 34gevent, 35gevent, 36gevent, 27slptravis
 
 [testenv]
-basepython = python2.7
 commands = coverage run --source=goless,tests setup.py test
 deps =
     coverage
@@ -12,27 +11,43 @@ setenv =
     GOLESS_BACKEND =
 
 [testenv:26gevent]
-basepython = python2.6
 deps =
     {[testenv]deps}
     unittest2
 
 [testenv:27gevent]
 
-[testenv:pypygevent]
+[testenv:pypy2gevent]
 basepython = pypy
 deps =
     {[testenv]deps}
-    git+https://github.com/surfly/gevent.git#gevent-egg
+    gevent
 setenv =
     GOLESS_BACKEND = gevent
 
-; See https://github.com/rgalanakis/goless/issues/21
-; for why we need this hackery (waiting for new gevent version).
+[testenv:pypy2stackless]
+basepython = pypy
+setenv =
+    GOLESS_BACKEND = stackless
+
+; Same as pypy2gevent
+[testenv:pypy3gevent]
+basepython = pypy3
+deps =
+    {[testenv]deps}
+    gevent
+setenv =
+    GOLESS_BACKEND = gevent
+
+; Same as pypy2stackless
+[testenv:pypy3stackless]
+basepython = pypy3
+setenv =
+    GOLESS_BACKEND = stackless
+
+
 [testenv:33gevent]
-basepython = python3.3
 commands =
-    pip install git+https://github.com/surfly/gevent.git#gevent-egg
     nosetests ./tests
 deps =
     {[testenv]deps}
@@ -40,9 +55,23 @@ deps =
 
 ; Same as 33 gevent
 [testenv:34gevent]
-basepython = python3.4
 commands =
-    pip install git+https://github.com/surfly/gevent.git#gevent-egg
+    nosetests ./tests
+deps =
+    {[testenv]deps}
+    cython
+
+; Same as 33 gevent
+[testenv:35gevent]
+commands =
+    nosetests ./tests
+deps =
+    {[testenv]deps}
+    cython
+
+; Same as 33 gevent
+[testenv:36gevent]
+commands =
     nosetests ./tests
 deps =
     {[testenv]deps}
@@ -51,6 +80,7 @@ deps =
 ; See https://github.com/rgalanakis/goless/issues/20
 ; for info about the Stackless Python (slp) environments.
 [testenv:27slptravis]
-basepython = {homedir}/stackless-2.7.6/bin/python
+basepython = {homedir}/cache/stackless-2.7.6/bin/python
+commands = python setup.py test
 setenv =
     GOLESS_BACKEND = stackless

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ basepython = pypy
 setenv =
     GOLESS_BACKEND = stackless
 
-; Same as pypy2gevent
 [testenv:pypy3gevent]
 basepython = pypy3
 deps =
@@ -39,12 +38,10 @@ deps =
 setenv =
     GOLESS_BACKEND = gevent
 
-; Same as pypy2stackless
 [testenv:pypy3stackless]
 basepython = pypy3
 setenv =
     GOLESS_BACKEND = stackless
-
 
 [testenv:33gevent]
 commands =
@@ -80,7 +77,8 @@ deps =
 ; See https://github.com/rgalanakis/goless/issues/20
 ; for info about the Stackless Python (slp) environments.
 [testenv:27slptravis]
-basepython = {homedir}/cache/stackless-2.7.6/bin/python
+basepython = {homedir}/.cache/stackless-2.7.6/bin/python
+; Coverage fails on stackless python; bypass for now
 commands = python setup.py test
 setenv =
     GOLESS_BACKEND = stackless


### PR DESCRIPTION
The CI config needs some love - it's currently failing on master because pip/travis/tox/python have changed in the past couple of years :)

The first thing that was causing CI to fail is that the no-longer-supported pip `--download-cache` option. I changed the caching to be more standard and modern, and added caching for the stackless python download.

On stackless python, `coverage` causes problems when running tests.  I tried pretty hard to fix it but failed, so changed the stackless tests to not run coverage for now. A little unfortunate, but not any worse than what's on master.

Support for pypy3, python 3.5, and python 3.6 has been added. Travis has really old versions of pypy though, so the latest versions are downloaded manually.

I noticed that pypy isn't being tested with the stackless backend, even though the examples seem to run fine with it. I added `pypy2stackless` and `pypy3stackless` Tox configurations, but the tests don't pass, so I'll leave them out of Travis until I/we/whoever can figure out what's causing them to fail. Again, not any worse off than what's in master.

In any case, this should get CI up and running again to prevent regressions.

(Bonus: the `gevent` installation hacks are no longer necessary since `gevent` has been updated, so that cleans some things up a little)