### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/DEVELOPERS.rst
+++ b/DEVELOPERS.rst
@@ -28,7 +28,7 @@ It also tells you what the install requirements are,
 and should be a help if you want to set up some sort of custom environment.
 
 Finally, please note that the `Travis CI project`_ runs
-all the supported configurations, so if you can't test all enviroments locally,
+all the supported configurations, so if you can't test all environments locally,
 you'll find out if you broke something once Travis runs.
 
 Running with Stackless

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,7 @@ import os
 sys.path.append(os.path.abspath('..'))
 
 # We may not have stackless or gevent available,
-# so just mock them out- we don't need them for autodoec.
+# so just mock them out- we don't need them for autodoc.
 import imp
 for name in 'stackless', 'gevent':
     sys.modules[name] = imp.new_module(name)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -192,7 +192,7 @@ class BackendChannelSenderReceiverPriorityTest(BaseTests):
     Tests if the current backend channel implementation has the correct
     sender/receiver priority (aka preference in stackless).
     Current implementations of goless channels
-    depend on receiver having the execution priotity!
+    depend on receiver having the execution priority!
     """
 
     def test_has_correct_sender_receiver_priority(self):


### PR DESCRIPTION
There are small typos in:
- DEVELOPERS.rst
- doc/conf.py
- tests/test_channels.py

Fixes:
- Should read `priority` rather than `priotity`.
- Should read `environments` rather than `enviroments`.
- Should read `autodoc` rather than `autodoec`.

Closes #57